### PR TITLE
Split GitHub Actions into build and publish components

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
-name: Build Unity
+﻿name: Publish Unity
 
 on:
-  pull_request: {}
+  push: 
+    branches: 
+      - main
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -53,3 +55,11 @@ jobs:
         with:
           name: ${{ matrix.targetPlatform }}
           path: build
+
+      - uses: josephbmanley/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+          CHANNEL: ${{ env.CHANNEL }}
+          ITCH_GAME: playground-unity-2d
+          ITCH_USER: beercan
+          PACKAGE: build

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Playing with Unity and 2D, along with other stuff.
 * https://github.com/marketplace/actions/unity-builder
 * https://unity-ci.com/docs/github
 * https://github.com/webbertakken/unity-actions
+* https://github.com/marketplace/actions/butler-push
+* https://github.community/t/syntax-for-replacing-characters-in-string/17240/2
 
 #### Travis
 * https://stablekernel.com/article/continuous-integration-for-unity-5-using-travisci/


### PR DESCRIPTION
Publish now supports itch.io publishing

Hack to convert platform into a channel

Removed tests step as we don't have any at this stage.